### PR TITLE
docs: WIL 1819 vs 1832 edition lineage (PWG/MW bases, OCR gap)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Edition lineage note (1819 vs 1832)** — [docs/WIL_EDITION_LINEAGE_1819_1832.md](https://github.com/sanskrit-lexicon/WIL/blob/main/docs/WIL_EDITION_LINEAGE_1819_1832.md) (Grok 4.5 `grok-4.5`, 02-08-2026): PWG ← WIL 1819; MW72/MW English base ← WIL 1832 (+ PWG matter); CDSL OCR is 1832 only; full 1819 body out of scope; 1819 preface is the bounded next OCR unit; `L.` (native lexicons) vs `W.` (Wilson) kept distinct with the European `L.`-stream transmission path through 1819.
+
 ## [0.1.0] - 2026-07-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # WIL — Wilson *A Dictionary, Sanscrit and English* (1832)
 
-_Created: 28-12-2014 · Last updated: 11-07-2026_
+_Created: 28-12-2014 · Last updated: 02-08-2026_
 
 Development and correction repository for **Horace Hayman Wilson's *A Dictionary, Sanscrit and English*, 2nd edition (Calcutta, 1832)**, a Sanskrit→English dictionary, part of the [Cologne Digital Sanskrit Lexicon](https://www.sanskrit-lexicon.uni-koeln.de/) (CDSL). The canonical source text lives in [`csl-orig/v02/wil/wil.txt`](https://github.com/sanskrit-lexicon/csl-orig/blob/main/v02/wil/wil.txt) (44,577 entries); this repository holds the development, correction, and enrichment work — Wilson↔Monier-Williams root correspondence, verb identification, botanical-name markup, and per-issue corrections.
 
-Wilson (1832) is the earliest dictionary in the CDSL collection and a documented ancestor of later works (Yates 1846, Goldstücker, Śabda-Sāgara), which is why much of the work here is **comparative** ([`wilmwroots/`](https://github.com/sanskrit-lexicon/WIL/tree/main/wilmwroots), [`verbs01/`](https://github.com/sanskrit-lexicon/WIL/tree/main/verbs01), [`maprep/`](https://github.com/sanskrit-lexicon/WIL/tree/main/maprep)).
+Wilson **1832** is the CDSL text and the English-gloss base of [MW72](https://github.com/sanskrit-lexicon/MW72) (and thus of MW1899's carried-forward English). Wilson **1819** (1st ed.) is the print base of [PWG](https://github.com/sanskrit-lexicon/PWG) and is **not** fully OCR'd at Cologne — see the lineage note below. Full 1819 body digitisation is out of scope for now; the **1819 preface** is the bounded next OCR unit.
+
+Wilson (1832) is the earliest dictionary **body** in the CDSL collection and a documented ancestor of later works (Yates 1846, Goldstücker, Śabda-Sāgara), which is why much of the work here is **comparative** ([`wilmwroots/`](https://github.com/sanskrit-lexicon/WIL/tree/main/wilmwroots), [`verbs01/`](https://github.com/sanskrit-lexicon/WIL/tree/main/verbs01), [`maprep/`](https://github.com/sanskrit-lexicon/WIL/tree/main/maprep)).
 
 ## Documentation
 
+- [docs/WIL_EDITION_LINEAGE_1819_1832.md](https://github.com/sanskrit-lexicon/WIL/blob/main/docs/WIL_EDITION_LINEAGE_1819_1832.md) — **1819 vs 1832**, PWG/MW72/MW chain, `L.`/`W.` distinction, OCR status, preface-only scope for 1819
 - [CLAUDE.md](https://github.com/sanskrit-lexicon/WIL/blob/main/CLAUDE.md) — repository guide and data-format reference.
 - [DATA_DICTIONARY.md](https://github.com/sanskrit-lexicon/WIL/blob/main/DATA_DICTIONARY.md) — markup tag reference.
 - [CONTRIBUTING.md](https://github.com/sanskrit-lexicon/WIL/blob/main/CONTRIBUTING.md) · [CODE_OF_CONDUCT.md](https://github.com/sanskrit-lexicon/WIL/blob/main/CODE_OF_CONDUCT.md)
@@ -27,7 +30,8 @@ Wilson (1832) is the earliest dictionary in the CDSL collection and a documented
 | [`issues/`](https://github.com/sanskrit-lexicon/WIL/tree/main/issues) | Per-issue working files |
 | [`CITATION.cff`](https://github.com/sanskrit-lexicon/WIL/blob/main/CITATION.cff) | Machine-readable citation metadata |
 | [`DATA_DICTIONARY.md`](https://github.com/sanskrit-lexicon/WIL/blob/main/DATA_DICTIONARY.md) | Markup tag reference |
-| [`WIL_1819_page59_iast.pdf`](https://github.com/sanskrit-lexicon/WIL/blob/main/WIL_1819_page59_iast.pdf) | Sample scan page (IAST) |
+| [`docs/WIL_EDITION_LINEAGE_1819_1832.md`](https://github.com/sanskrit-lexicon/WIL/blob/main/docs/WIL_EDITION_LINEAGE_1819_1832.md) | Edition lineage: 1819 (PWG base) vs 1832 (CDSL/MW72 base); OCR gaps |
+| [`WIL_1819_page59_iast.pdf`](https://github.com/sanskrit-lexicon/WIL/blob/main/WIL_1819_page59_iast.pdf) | Sample **1819** scan page only (IAST) — not full OCR |
 
 ## Timeline
 

--- a/docs/WIL_EDITION_LINEAGE_1819_1832.md
+++ b/docs/WIL_EDITION_LINEAGE_1819_1832.md
@@ -1,0 +1,73 @@
+# Wilson edition lineage — 1819 vs 1832 (PWG / MW / MW72)
+
+_Created: 02-08-2026 · Last updated: 02-08-2026_
+
+**Canonical home for the two Wilson print editions and how they feed the European
+dictionary line.** CDSL digitises only the **1832** text; this note records the
+**1819** base, the edition-split rule, OCR status, and what is (and is not) next.
+
+## Two print editions
+
+| Edition | Full title (short) | Place | Role in the European line |
+|---|---|---|---|
+| **WIL 1819** | H. H. Wilson, *A Dictionary, Sanscrit and English*, **1st ed.** | Calcutta | **Basis of PWG** (Böhtlingk–Roth). Not digitised at Cologne. |
+| **WIL 1832** | same, **2nd ed.** | Calcutta (Education Press) | **Basis of MW72** English stock (over which PWG matter was added). **This** is what CDSL / this repo digitise as `wil`. |
+
+House rule of thumb:
+
+- **PWG relies on WIL 1819.**
+- **MW (via MW72) relies on WIL 1832** for the English-gloss base; MW1899 then brings English meanings forward from MW72 and continues to rework PWG.
+
+```text
+WIL 1819  ──basis──►  PWG (1855–75)  ──condensed/reworked──►  MW 1899 (structure, cites, German philology)
+WIL 1832  ──basis──►  MW72 (1872)    ──English meanings carried forward──►  MW 1899
+                         ▲
+                         └── PWG matter added on top of the WIL 1832 English base
+```
+
+## MW citation markers — do not collapse `L.` and `W.`
+
+Two distinct MW `<ls>` markers sit next to this lineage; they are **not** interchangeable.
+
+| Marker | MW's own expansion | How it relates to Wilson editions |
+|---|---|---|
+| **`W.`** | Wilson — words/meanings on Wilson's authority (MW 1899 preface: "All the words and meanings marked W. … rest on his authority") | Editorial cross-ref to Wilson; CDSL's Wilson text is **1832**. Count ~8,286 in MW. |
+| **`L.`** | **Lexicographers** — word/meaning met only in **native lexicons**, not in a published literary work (MW 1899 preface, directions for use) | **Not** a Wilson siglum. Transmission note (MG, 02-08-2026): the European capture of the dictionary-tradition stream that MW compresses under `L.` is to be **traced into WIL 1819**, which PWG took as its print base (PWG then names individual koshas; MW collapses those named kosha-only cites into the single `L.` hedge). |
+
+So: **surface tag** `L.` = native lexicons (MW's definition, load-bearing); **historical path** for that European stream = **WIL 1819 → PWG → MW `L.`**. Do not re-expand `L.` as "Wilson".
+
+Cross-refs in house docs: [MWS DICT_PROFILE — citation markers](https://github.com/sanskrit-lexicon/MWS/blob/master/DICT_PROFILE.md#citation-markers--not-all-are-literary-works), [Lineage section](https://github.com/sanskrit-lexicon/MWS/blob/master/DICT_PROFILE.md#lineage-wil--koshas-mw--pwg).
+
+## Digitisation / OCR status (Cologne)
+
+| Edition | Full body OCR / CDSL text | Front matter (preface) |
+|---|---|---|
+| **WIL 1832** | **Yes** — `csl-orig/v02/wil/wil.txt` (~44,577 entries); Cologne WIL scan + this repo | Cologne / csl-doc has wilpref material for the **1832** line |
+| **WIL 1819** | **No** full OCR at Cologne; not in CDSL body text | **None yet** — actionable now (see below) |
+
+Local residue of 1819 already in this repo: sample page
+[`WIL_1819_page59_iast.pdf`](https://github.com/sanskrit-lexicon/WIL/blob/main/WIL_1819_page59_iast.pdf)
+(one page, not a substitute for front matter or body).
+
+## Scope discipline (02-08-2026)
+
+| Work | Status |
+|---|---|
+| Full WIL **1819** body digitisation | **Not needed now** — large task; do not open unless a human re-scopes |
+| WIL **1819 preface** (front matter OCR + EN, optional RU) | **Doable now** — same `/cologne-preface-ocr` shape as other dict prefaces; park under `prefaces/` when scans are in hand |
+| Treat CDSL `wil` as 1832 | Standing — never label the digitised body as 1819 |
+
+## Implications for comparative / forensic work
+
+1. **Edition-sensitive joins.** A headword/gloss agreement with "Wilson" is not edition-free: PWG-side ancestry expects **1819**; MW/MW72 English stock expects **1832**. Mixing them without naming the edition confounds "copied Wilson" tests.
+2. **`L.` tracing.** To follow the European dictionary-tradition stream behind an MW `L.` hedge, use **WIL 1819** (and PWG's named kosha cites) as the European intermediate — not the 1832 CDSL text alone, and not by rewriting the tag expansion.
+3. **`W.` tracing.** Use WIL **1832** (CDSL `wil`) for material MW marks `W.`.
+4. **MW72** has **zero** `<ls>` tags ([FINDINGS §511](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md#511-mw72-carries-zero-ls-source-citations--every-cross-dictionary-citation-test-that-names-it-shrinks-to-mw)) — English-base comparison to WIL 1832 is content-level, not citation-tag-level.
+
+## Registry / hub pointers
+
+- Sanskrit-data finding: [FINDINGS §515](https://github.com/gasyoun/SanskritLexicography/blob/master/FINDINGS.md) (edition split + OCR gap).
+- Prefaces skill: `/cologne-preface-ocr` (Fable 5 / vision OCR).
+- Related repos: [PWG](https://github.com/sanskrit-lexicon/PWG), [MW72](https://github.com/sanskrit-lexicon/MW72), [MWS](https://github.com/sanskrit-lexicon/MWS).
+
+_Dr. Mārcis Gasūns_


### PR DESCRIPTION
## Summary
Records the standing edition-basis facts so they are not lost:

- **PWG** rests on **WIL 1819** (1st ed.)
- **MW72 / MW** English stock rests on **WIL 1832** (+ PWG matter); MW1899 carries English from MW72
- CDSL body OCR is **1832 only**; full 1819 body out of scope
- **1819 preface** is the bounded next OCR unit (handoff H2213)
- MW `L.` stays native-lexicons (not Wilson); European `L.`-stream traces via 1819; `W.` = Wilson/1832

Canonical: `docs/WIL_EDITION_LINEAGE_1819_1832.md` + README pointer + CHANGELOG.

## Test plan
- [x] Doc-only; no code
